### PR TITLE
Add on-the-fly reload and misc other changes

### DIFF
--- a/Community/Expire/automation/jsr223/python/community/expire/expire.py
+++ b/Community/Expire/automation/jsr223/python/community/expire/expire.py
@@ -8,17 +8,17 @@ Requirements:
 
 Limitations:
     - The expire config metadata string must include the default units when
-    using with Items that are defined with Units of Measure.
+      using with Items that are defined with Units of Measure.
 
     - Adding new Items or changing Items with an expire metadata config requires
-    a reload of this script to regenerate the rule triggers.
+      a reload of this script to regenerate the rule triggers.
 
 Differences from the binding:
     - You can expire a String Item to an empty string: expire="5s,state=''"
 
     - In the binding, expire="5s,state=UNDEF" will set a StringItem to the
-    String "UNDEF". This script will set the String Item to UnDefType.UNDEF.
-    To set a String Item to the String "UNDEF", use expire="5s,state='UNDEF'"
+      String "UNDEF". This script will set the String Item to UnDefType.UNDEF.
+      To set a String Item to the String "UNDEF", use expire="5s,state='UNDEF'"
 
 License
 =======
@@ -32,16 +32,15 @@ from datetime import timedelta
 from core.actions import ScriptExecution
 from org.joda.time import DateTime
 from core.log import logging, LOG_PREFIX, log_traceback
-from org.openhab.core.library.items import StringItem
 
-init_logger = logging.getLogger("{}.Expire Init".format(LOG_PREFIX))
 regex = re.compile(r'^((?P<days>[\.\d]+?)d)? *((?P<hours>[\.\d]+?)h)? *((?P<minutes>[\.\d]+?)m)? *((?P<seconds>[\.\d]+?)s)?$')
 timers = { }
 special = { "UNDEF": UnDefType.UNDEF,
             "NULL":  UnDefType.NULL }
 
-@log_traceback
-def parse_time(time_str):
+
+
+def parse_time(time_str, log):
     """
     Parse a time string e.g. (2h13m) into a timedelta object
 
@@ -60,22 +59,26 @@ def parse_time(time_str):
               - 1h05s
               - 55h 59m 12s
     Returns:
-        datetime.timedelta: A datetime.timedelta object representing the
-        supplied time duration.
+        A ``datetime.timedelta`` object representing the supplied time duration
+        or ``None`` if ``time_str`` cannot be parsed.
     """
     parts = regex.match(time_str)
-    assert parts is not None, ("Could not parse any time information from '{}'."
-                               "  Examples of valid strings: '8h', '2d8h5m20s',"
-                               " '2m4s'".format(time_str))
-    time_params = {name: float(param) for name, param in parts.groupdict().items() if param}
-    return timedelta(**time_params)
+    if parts is None:
+        log.warn("Could not parse any time information from '{}'. Examples "
+                  "of valid strings: '8h', '2d8h5m20s', '2m 4s'"
+                   .format(time_str))
+        return None
+    else:
+        time_params = {name: float(param) for name, param in parts.groupdict().items() if param}
+        return timedelta(**time_params)
 
-@log_traceback
-def get_config(item_name):
+
+def get_config(item_name, log):
     """
     Parses the config string to extract the time duration, type of event, and
-    the necessary state. The config string is stored in an "exp" metadata entry.
-    The config takes format of exp="<duration>[,][command=|state=][<new state>]"
+    the necessary state. The config string is stored in an "expire" metadata
+    entry.The config takes format of
+    ``expire="<duration>[,][command=|state=][<new state>]"``
         - <duration>: a time duration of the format described in parse_time.
         - [,]: if supplying more than just the duration, a comma is required
         here.
@@ -103,89 +106,83 @@ def get_config(item_name):
                                      "UNDEF")
     """
     cfg = get_value(item_name, "expire")
-    time = cfg
+    if cfg:
+        cfg = cfg.split(",")
+    else:
+        return None
+
+    time = parse_time(cfg[0], log)
+    if not time:
+        return None
     event = "state"
-    state = UNDEF
 
-    # If it contains a ',' there is a state supplied, split and assign the left
-    # to time and right to state.
-    if ',' in cfg:
-        time = cfg.split(',')[0]
-        state = cfg.split(',')[1]
+    # If config has a state len will be 2
+    if len(cfg) > 1:
+        state = cfg[1].split("=")
 
-        # If it contians a '=' there is an event type supplied, split and assign
-        # the left to event and right to state.
-        if '=' in state:
-            event = state.split('=')[0]
-            state = state.split('=')[1]
+        # If config has an event type it will be 2
+        if len(state) > 1:
+            event = state[0].strip().lower()
+            state = state[1]
+        else:
+            state = state[0]
 
         # Check for special types.
         if state in special:
             state = special[state]
 
-        # Check for and remove single quotes from state.
-        elif state.startswith("'") and state.endswith("'"):
-            state = state.replace("'", "")
+        # Remove single quotes from state.
+        else:
+            state = state.strip("'")
 
-    td = parse_time(time)
+        state = state if state.strip() != "" else UNDEF
 
-    return { "time":td, "type":event, "state":state }
+        # Force the state to a StringType for StringItems to allow us to set the
+        # Item to "UNDEF" and "NULL" as opposed to the UnDefTypes.
+        if ir.getItem(item_name).type == "String":
+            if isinstance(state, basestring):
+                state = StringType(state)
+        # Strip whitespace for non String items
+        elif isinstance(state, basestring):
+            state = state.strip()
 
-# TODO listen for Item added/removed events and regenerate the Rule and its
-# triggers.
+    # No state supplied, clear item state
+    else:
+        state = UNDEF
 
-@log_traceback
-def trigger_generator():
-    """
-    Generates triggers for the Expire Rule for all Items that have the expire
-    metadata value set.
-    """
-    def generate_triggers(function):
-        for item_name in [i for i in items if get_value(i, "expire")]:
-            try:
-                get_config(item_name)
-            except AssertionError:
-                init_logger.log.error("Expire config on {} is not valied: {}"
-                                      .format(item_name,
-                                              get_value(item_name, "expire")))
-            else:
-                when("Item {} received update".format(item_name))(function)
-        return function
-    return generate_triggers
+    if event not in ["state", "command"]:
+        log.warn("Unrecognized action '{}' for item '{}'"
+                 .format(event, item_name))
+        return None
 
-@log_traceback
+    return { "time": time, "type": event, "state": state }
+
+
 def expired(item, exp_type, exp_state, log):
     """
-    Called when an Item expires. postUpdate or sendCommand to the configured
+    Called when an Item expires, postUpdate or sendCommand to the configured
     state.
 
     Arguments:
         - item: The Item that expired.
-        - cfg: Contians a dict representation of the expire config returned by
-        get_config.
-        - log: Logger from the expire Rule.
+        - exp_type: The action type, 'state' or 'command'.
+        - exp_state: The state to expire to.
+        - log: Logger from the expire rule.
     """
-    log.debug("{} expired, {} to {}".format(item.name, exp_type, exp_state))
-
-    # Force the state to a StringType for StringItems to allow us to set the
-    # Item to "UNDEF" and "NULL" as opposed to the UnDefTypes.
-    if item.type == "String" and isinstance(exp_state, basestring):
-        exp_state = StringType(exp_state)
+    log.debug("'{}' expired, {} '{}'".format(item.name, exp_type, exp_state))
 
     if exp_type == "state":
         events.postUpdate(item, exp_state)
-    else:
+    elif exp_type == "command":
         events.sendCommand(item, exp_state)
+    else:
+        log.warn("Unrecognized action '{}' for item '{}'"
+                 .format(exp_type, item.name))
 
-@rule("Expire",
-      description=("Simulates the Expire1 binding, updating or commanding an "
-                   "Item after a comnfigured amount of time."),
-       tags=["expire"])
-@trigger_generator()
+
 def expire(event):
     """
-    Called when a member of the configured Group changes. The name of the Group
-    is imported from configuration as expire_items_gr.
+    Called when an item configured for expire receives an update.
 
     If the Item updates to an UnDefType, the change is ignored.
     If the Item updates to the same state configured in the expire config any
@@ -193,37 +190,155 @@ def expire(event):
     If the Item updates to a different state configured in the expire config a
     new timer is created to go off at the configured time in the future.
     """
+    item_name = event.itemName
+
     # Ignore changes to an UnDefType.
     if isinstance(event.itemState, UnDefType):
+        if (timers[item_name] is not None
+                and not timers[item_name].hasTerminated()):
+            timers[item_name].cancel()
         return
 
-    cfg = get_config(event.itemName)
+    cfg = get_config(item_name, expire.log)
+    if not cfg:
+        expire.log.warn("Skipping expire processing for '{}'"
+                        .format(item_name))
+        if (timers[item_name] is not None
+                and not timers[item_name].hasTerminated()):
+            timers[item_name].cancel()
+        return
 
     # Cancel the timer when the Item enters the cfg state.
     # Use unicode because there is no degree symbol in ASCII so we can handle
     # Number:Temperature Items.
-    if unicode(items[event.itemName]) == cfg["state"]:
-        if (event.itemName in timers
-                and not timers[event.itemName].hasTerminated()):
-            timers[event.itemName].cancel()
-            del timers[event.itemName]
+    if unicode(items[item_name]) == cfg["state"]:
+        if (timers[item_name] is not None
+                and not timers[item_name].hasTerminated()):
+            timers[item_name].cancel()
+        return
 
     # Create an expire timer when the Item differs from the end state.
+    expire.log.debug("Setting timer for '{}' with delay {}"
+                     .format(item_name, cfg["time"]))
+    t = (DateTime.now().plusDays(cfg["time"].days)
+                        .plusSeconds(cfg["time"].seconds)
+                        .plusMillis(int(cfg["time"].microseconds/1000)))
+    if (timers[item_name] is not None
+            and not timers[item_name].hasTerminated()):
+        timers[item_name].reschedule(t)
     else:
-        t = (DateTime.now().plusDays(cfg["time"].days)
-                           .plusSeconds(cfg["time"].seconds)
-                           .plusMillis(int(cfg["time"].microseconds/1000)))
-        if event.itemName in timers:
-            timers[event.itemName].reschedule(t)
+        timers[item_name] = ScriptExecution.createTimer(
+            t,
+            lambda: expired(ir.getItem(item_name),
+                            cfg["type"],
+                            cfg["state"],
+                            expire.log)
+        )
+
+
+def expire_load(event):
+
+    log = logging.getLogger("{}.Expire Load".format(LOG_PREFIX))
+    log.debug("Expire loading...")
+
+    # Keep track of items configured this pass
+    new_items = []
+
+    # Scan for items with valid expire config
+    for item_name in items:
+        cfg = get_config(item_name, log)
+        if cfg:
+            new_items.append(item_name)
+            timers[item_name] = timers.get(item_name, None) # don't clobber
+            log.debug("Expire configured for '{}' with timeout {} to {} '{}'"
+                      .format(item_name, cfg["time"],
+                      cfg["type"], cfg["state"]))
+
+    # Remove existing rule
+    if hasattr(expire, "UID"):
+        rules.remove(expire.UID)
+        delattr(expire, "triggers")
+        delattr(expire, "UID")
+
+    # Generate triggers
+    for item_name in new_items:
+        when("Item {} received update".format(item_name))(expire)
+
+    # Create expire rule
+    if hasattr(expire, "triggers"):
+        rule(
+            "Expire",
+            description=("Simulates the Expire1 binding, updating or commanding an "
+                         "Item after a configured amount of time."),
+            tags=["expire"]
+        )(expire)
+        if hasattr(expire, "UID"):
+            log.info("Expire loaded successfully")
         else:
-            timers[event.itemName] = ScriptExecution.createTimer(t,
-                                     lambda: expired(ir.getItem(event.itemName),
-                                                     cfg["type"],
-                                                     cfg["state"],
-                                                     expire.log))
+            log.error("Failed to create Expire rule")
+    else:
+        log.info("Expire found no configured items")
+
+    # Drop items that no longer exist or have expire config
+    for item_name in timers:
+        if item_name not in new_items:
+            if item_name in items:
+                log.debug("Removing item '{}' as it no longer has a valid expire config"
+                          .format(item_name))
+            else:
+                log.debug("Removing item '{}' as it no longer exists"
+                          .format(item_name))
+            if (timers[item_name] is not None
+                    and not timers[item_name].hasTerminated()):
+                timers[item_name].cancel()
+            timers.pop(item_name, None)
+
 
 @log_traceback
-def scriptUnloaded():
-    """ Called at script unload, cancel all the latent timers. """
-    for key in timers:
-        timers[key].cancel()
+def scriptLoaded(*args):
+    """
+    Called at script load, sets up the reload rule.
+    """
+    log = logging.getLogger("{}.Expire Init".format(LOG_PREFIX))
+
+    import configuration
+    if hasattr(configuration, "expire_reload_item"):
+        item_name = configuration.expire_reload_item
+    else:
+        item_name = "expire_reload"
+        log.debug("No value for 'expire_reload_item' in configuration.py, "
+                  "using default item 'expire_reload'")
+
+    if item_name in items:
+        when("Item {} received command ON".format(item_name))(expire_load)
+        rule(
+            "Expire Reload",
+            description=("Reloads the Expire script, adding items that did not "
+                            "have a valid expire config and removing items that have "
+                            "been deleted or no longer have a valid expire config"),
+            tags=["expire"]
+        )(expire_load)
+        if hasattr(expire_load, "UID"):
+            log.info("Expire Reload rule created successfully")
+        else:
+            log.error("Failed to create Expire Reload rule")
+    else:
+        if hasattr(configuration, "expire_reload_item"):
+            log.warn("Unable to create Expire Reload rule, item '{}' does not exist"
+                     .format(item_name))
+        else:
+            log.debug("Unable to create Expire Reload rule, item '{}' does not exist"
+                      .format(item_name))
+
+    expire_load(None)
+
+
+@log_traceback
+def scriptUnloaded(*args):
+    """
+    Called at script unload, cancel all running timers.
+    """
+    for item_name in timers:
+        if (timers[item_name] is not None
+                and not timers[item_name].hasTerminated()):
+            timers[item_name].cancel()


### PR DESCRIPTION
Added on-the-fly reload using a switch item. This item can be specified in `configuration.py` using the key `expire_reload_item`, if it is omitted and an item called `expire_reload` exists it will bind the reload rule to that item. The command `ON` will trigger a reload of the script.

When the script is reloaded it will purge any items in it's list that no longer exist or no longer have a valid expire config, and of course add an items that now have a valid config. In order to facilitate the live reload I had to remove your trigger generator decorator and build similar code into the `expire_load` function.

I also modified the `get_config` and `parse_time` functions to return `None` if the input is invalid, I think this is a cleaner way to catch config errors. I modified the parsing of the config string a little as well to make it a little more efficient.

And finally I cleaned up a couple docstrings and added a bit more logging because I wanted to see a bit more what was going on when I was testing.

**One thing to note:** I have not had time yet to test the reload process. I have had no issues with the initial load though, so I don't expect there to be problems.

Signed-off-by: Michael Murton <6764025+CrazyIvan359@users.noreply.github.com>